### PR TITLE
Update links to aerynos.dev

### DIFF
--- a/src/content/docs/tooling/boulder.mdx
+++ b/src/content/docs/tooling/boulder.mdx
@@ -17,4 +17,4 @@ To do so, we created `stone.yaml`. This YAML file contains some basic metadata, 
 steps complete with centrally configured **macros** for easily creating package builds in a distro-consistent fashion.
 It is designed as a successor to the `package.yml` format from the [ypkg](https://github.com/getsolus/ypkg) tool in [Solus](https://getsol.us).
 
-For more information, please see the [packaging documentation](https://dev.aerynos.com/packaging)
+For more information, please see the [packaging documentation](https://aerynos.dev/packaging/)

--- a/src/content/docs/tooling/moss.mdx
+++ b/src/content/docs/tooling/moss.mdx
@@ -24,7 +24,7 @@ scoped "triggers" in namespace, and separating from so-called "system triggers".
 
 Additionally we required a type-safe binary format for storing our packages, emitted by `boulder`. This creates
 `.stone` archives that are internally deduplicated, use `zstd` compression and `xxhash` for content addressing.
-For more information, please see the [stone format documentation](https://dev.aerynos.com/stone-format).
+For more information, please see the [stone format documentation](https://aerynos.dev/developers/stone/).
 
 With that said, we think we've done a pretty good job at keeping these internals tidy and presenting a classical
 feeling package manager that doesn't sacrifice on user choice or require a steep learning curve, all while providing


### PR DESCRIPTION
A couple of links 404'ed as they linked to the old urls. This commit corrects those links