### PR TITLE
Change image size in our banner / hero image

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import BoxSectionOutro from '@/components/splash/BoxSectionOutro.astro';
 
 <SplashContent>
 <div class="image-container">
-  <Image src={myImage} alt="Centered Image" width={400} height={400} />
+  <Image src={myImage} alt="Centered Image" width={250} height={250} />
 </div>
 <h1>AerynOS</h1>
   <p>AerynOS is an independent performance-oriented Linux-based operating system that diverges significantly from traditional distributions whilst still aiming to provide a familiar and comfortable environment. The code-base is currently in an alpha "technical preview" stage, which means that it is not yet ready for widespread use. However, we are committed to eventually providing a stable and reliable operating system that will be easy to use and customize.</p>


### PR DESCRIPTION
We find the main logo on the website is 2 large. This change updates the dimensions to 250 by 250.
instead of 400 x 400.
Comparisons below of 400 x 400 to 300 x 300 to 250 x 250 to 200 x 200. From smallest to largest.

<img width="1500" height="701" alt="image" src="https://github.com/user-attachments/assets/572fcf30-b298-4114-a757-c51932f7c582" />
<img width="1500" height="701" alt="image(1)" src="https://github.com/user-attachments/assets/5f823eb7-39ec-451e-b586-4bd69b539fe0" />
<img width="1500" height="701" alt="image(2)" src="https://github.com/user-attachments/assets/0370b932-8c1c-43fa-bba2-0f6d20febab2" />
<img width="1500" height="701" alt="image(3)" src="https://github.com/user-attachments/assets/0249ec99-2589-4044-b0bc-32b5d3492656" />
