### PR TITLE
Update about

### DIFF
--- a/src/content/docs/about.mdx
+++ b/src/content/docs/about.mdx
@@ -13,7 +13,7 @@ import Card from "@/components/ui/Card.astro";
   delivering a safe and efficient system 🐍
 </Card>
 
-Our fully atomic system leverages the [LLVM](https://llvm.org/) toolchain and libstdc++ by default, delivering superior diagnostics and package diversity. We're not afraid to challenge convention - thoughtfully replacing traditional components with modern alternatives that prioritize safety and reliability.
+Our fully atomic system leverages the [LLVM](https://llvm.org/) toolchain and GNU libstdc++ by default, delivering superior diagnostics and package diversity. We're not afraid to challenge convention - thoughtfully replacing traditional components with modern alternatives that prioritize safety and reliability.
 
 We closely follow the work of organizations dedicated to making software safer, including the [Prossimo project](https://www.memorysafety.org/) and their Memory Safety initiative, the [Tweede Golf](https://tweedegolf.nl/en) team, and the [Trifecta Tech Foundation](https://trifectatech.org/). By monitoring and adopting innovations from these pioneers, we can integrate proven solutions like memory-safe replacements for critical system components.
 


### PR DESCRIPTION
During the October 2025 blog post, we highlighted that we switched back to GNU libstdc++ from LLVM libcxx

https://aerynos.com/blog/2025/10/31/#switching-back-to-gnu-libstdc-from-llvm-libcxx

Update our About page to correctly reflect this on our main site.

Resolves https://github.com/AerynOS/dotcom/issues/53