### PR TITLE
global.css: Update branding colours and make content pages wider.

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,9 +4,9 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 
 /* Dark mode colors. */
 :root {
-	--sl-color-accent-low: #36113e;
-	--sl-color-accent: #a400c0;
-	--sl-color-accent-high: #e3b6ed;
+    --sl-color-accent-low: #f0bb78ff;
+	--sl-color-accent: #f5ecd5;
+	--sl-color-accent-high: #626f47ff;
 	--sl-color-white: #ffffff;
 	--sl-color-gray-1: #eeedf1;
 	--sl-color-gray-2: #c9c7cc;
@@ -15,12 +15,14 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 	--sl-color-gray-5: #39373e;
 	--sl-color-gray-6: #27262c;
 	--sl-color-black: #18181b;
+	--sl-content-width: 70rem;
+	--sl-breakpoint-lg: 100rem;
 }
 /* Light mode colors. */
 :root[data-theme='light'] {
-	--sl-color-accent-low: #ebc9f3;
-	--sl-color-accent: #8b00a3;
-	--sl-color-accent-high: #4e0e5b;
+    --sl-color-accent-low: #d3a569d4;
+	--sl-color-accent: #626f47ff;
+	--sl-color-accent-high: #A4B465;
 	--sl-color-white: #18181b;
 	--sl-color-gray-1: #27262c;
 	--sl-color-gray-2: #39373e;
@@ -30,6 +32,8 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 	--sl-color-gray-6: #eeedf1;
 	--sl-color-gray-7: #f6f6f8;
 	--sl-color-black: #ffffff;
+	--sl-content-width: 70rem;
+	--sl-breakpoint-lg: 100rem;
 }
 
 /*


### PR DESCRIPTION
# Summary

Update global.css to change to new branding color scheme and adjust the site width up so it's not too narrow on higher resolution screens. This also helps with the size of images / diagrams also.

# Testing

Built site locally and checked it was working