### PR TITLE
Home Page: fix mobile layout

### DIFF
--- a/src/content/docs/blog/2022/06/22/packaging-automation-next-steps/index.mdx
+++ b/src/content/docs/blog/2022/06/22/packaging-automation-next-steps/index.mdx
@@ -15,7 +15,7 @@ packaging templates from an upstream source (i.e. tarball).
 
 Before we really start this blog post off, I'd like to thank everyone who is supporting the
 project! All of the [OpenCollective](https://opencollective.com/serpent-os) contributions will make it easier for me to work full
-time on Serpent OS =) Much love <3
+time on Serpent OS =) Much love &lt;3
 
 ![Look at all the buildiness](./Featured.webp)
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -32,7 +32,7 @@ import BoxSectionOutro from '@/components/splash/BoxSectionOutro.astro';
 <h1>AerynOS</h1>
   <p>AerynOS is an independent performance-oriented Linux-based operating system that diverges significantly from traditional distributions whilst still aiming to provide a familiar and comfortable environment. The code-base is currently in an alpha "technical preview" stage, which means that it is not yet ready for widespread use. However, we are committed to eventually providing a stable and reliable operating system that will be easy to use and customize.</p>
 
-  <div class="sl-flex" style="justify-content: center; flex-wrap: wrap;">
+  <div class="button-grid">
     <LinkButton href="/download" variant="primary" icon="fa6-solid:download">Get Started</LinkButton>
     <LinkButton href="/about" variant="secondary" icon="fa6-solid:circle-arrow-right">Learn More</LinkButton>
     <LinkButton href="/sponsor" variant="secondary" iconPlacement="end" icon="fa6-solid:heart">Support Us</LinkButton>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -32,7 +32,7 @@ import BoxSectionOutro from '@/components/splash/BoxSectionOutro.astro';
 <h1>AerynOS</h1>
   <p>AerynOS is an independent performance-oriented Linux-based operating system that diverges significantly from traditional distributions whilst still aiming to provide a familiar and comfortable environment. The code-base is currently in an alpha "technical preview" stage, which means that it is not yet ready for widespread use. However, we are committed to eventually providing a stable and reliable operating system that will be easy to use and customize.</p>
 
-  <div class="sl-flex" style="justify-content: center;">
+  <div class="sl-flex" style="justify-content: center; flex-wrap: wrap;">
     <LinkButton href="/download" variant="primary" icon="fa6-solid:download">Get Started</LinkButton>
     <LinkButton href="/about" variant="secondary" icon="fa6-solid:circle-arrow-right">Learn More</LinkButton>
     <LinkButton href="/sponsor" variant="secondary" iconPlacement="end" icon="fa6-solid:heart">Support Us</LinkButton>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -55,6 +55,19 @@ html:not([data-has-sidebar]) .content-panel {
 
 
 
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .button-grid {
+    grid-template-columns: repeat(4, auto);
+  }
+}
+
 .splash-content {
   padding: 1rem 1.5rem;
   margin-inline: auto;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -56,10 +56,11 @@ html:not([data-has-sidebar]) .content-panel {
 
 
 .splash-content {
-  padding: 1rem;
+  padding: 1rem 1.5rem;
   margin-inline: auto;
   max-width: 80rem;
-  width: calc(var(--original-sl-content-width) +(100% - var(--original-sl-content-width) - var(--sl-sidebar-width)) / 2);
+  width: 100%;
+  box-sizing: border-box;
   text-align: center;
 }
 
@@ -71,7 +72,13 @@ html:not([data-has-sidebar]) .content-panel {
   flex-direction: column;
   align-items: center;
   gap: 1rem;
-  padding: 4rem;
+  padding: 2rem 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .box-section {
+    padding: 4rem;
+  }
 }
 
 


### PR DESCRIPTION
# Summary

The other day I checked out the website on my phone while on my way home in the train, and I saw that the layout of the home page was broken on mobile. I thought that this was a shame, so I made this PR to fix it. 

For me it seems to be working way better than it was before. However, the layout of the home page doesn't lend itself too well for mobile, so it still isn't the prettiest thing ever, but I didn't want to change anything to drastically. 

This is my first contribution, so I just tried to follow the style of the other commit messages in the commit log.

# Testing

To test you can just use your browser's dev tools to see how the layout adapts to different screen sizes. 

