### PR TITLE
edition/gnome: Update iso+sha256sum to 2026.05.2

### DIFF
--- a/src/components/ui/EditionInfo.astro
+++ b/src/components/ui/EditionInfo.astro
@@ -46,7 +46,7 @@ let { Content } = await render(edition);
 
       <LinkButton
         variant="secondary"
-        href="magnet:?xt=urn:btih:f423156eb729cf6afa2f73470d906eaae5f11696&xt=urn:btmh:122077e3d2273f5c9fb9e25fad3e580c1b6a36e5c7d92ae019697c5b24003e135329&dn=AerynOS-2026.05-GNOME-live-x86_64.iso&xl=2533359616&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.theoks.net%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ffosstorrents.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker-udp.gbitt.info%3A80%2Fannounce&tr=http%3A%2F%2Ffosstorrents.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fopentracker.io%3A6969%2Fannounce&ws=https://cdn.aerynos.dev/isos/AerynOS-2026.05-GNOME-live-x86_64.iso"
+        href="magnet:?xt=urn:btih:269cb5a9dced84cef8f594106341d93715ac479d&dn=AerynOS-2026.05.2-GNOME-live-x86_64.iso&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker-udp.gbitt.info%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.theoks.net%3A6969%2Fannounce&tr=udp%3A%2F%2Ffosstorrents.com%3A6969%2Fannounce&tr=http%3A%2F%2Ffosstorrents.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fopentracker.io%3A6969%2Fannounce&ws=https%3A%2F%2Fcdn.aerynos.dev%2Fisos%2FAerynOS-2026.05.2-GNOME-live-x86_64.iso"
         icon="tabler:magnet">Torrent magnet</LinkButton
       >
 

--- a/src/content/edition/gnome.mdx
+++ b/src/content/edition/gnome.mdx
@@ -2,9 +2,9 @@
 title: "GNOME Edition"
 screenshot: "@/images/editions/AerynOS_Gnome_May26.png"
 screenshot_desc: "GNOME Edition"
-version: "2026.05 (alpha) 🧪"
-url: "https://cdn.aerynos.dev/isos/AerynOS-2026.05-GNOME-live-x86_64.iso"
-checksum_url: "https://cdn.aerynos.dev/isos/AerynOS-2026.05-GNOME-live-x86_64.iso.sha256sum"
+version: "2026.05.2 (alpha) 🧪"
+url: "https://cdn.aerynos.dev/isos/AerynOS-2026.05.2-GNOME-live-x86_64.iso"
+checksum_url: "https://cdn.aerynos.dev/isos/AerynOS-2026.05.2-GNOME-live-x86_64.iso.sha256sum"
 ---
 
 AerynOS with [GNOME Desktop](https://www.gnome.org/). Solid GTK integration in a clean, functional package that gets out of your way. We built this to actually work - no bloat, no buzzwords, just a damn good desktop that lets you get things done.


### PR DESCRIPTION
Still missing .torrent magnet link.

When adding that, glease git commit --amend over this commit and merge.